### PR TITLE
remove dependency from node exporter

### DIFF
--- a/Grafana_Dashboard.json
+++ b/Grafana_Dashboard.json
@@ -64,11 +64,11 @@
           "datasource": "${DS_PROMETHEUS}",
           "editable": true,
           "error": false,
-          "format": "percent",
+          "format": "bytes",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
-            "show": true,
+            "show": false,
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
@@ -110,7 +110,7 @@
           },
           "targets": [
             {
-              "expr": "(sum(node_memory_MemTotal) - sum(node_memory_MemFree+node_memory_Buffers+node_memory_Cached) ) / sum(node_memory_MemTotal) * 100",
+              "expr": "sum(container_memory_usage_bytes{image!=\"\"})",
               "interval": "10s",
               "intervalFactor": 1,
               "refId": "A",
@@ -189,7 +189,7 @@
           },
           "targets": [
             {
-              "expr": "sum(sum by (container_name)( rate(container_cpu_usage_seconds_total{image!=\"\"}[1m] ) )) / count(node_cpu{mode=\"system\"}) * 100",
+              "expr": "sum(rate(container_cpu_user_seconds_total{image!=\"\"}[1m])) / count(machine_cpu_cores) * 100",
               "interval": "10s",
               "intervalFactor": 1,
               "refId": "A",


### PR DESCRIPTION
I'd like to suggest to stick to the metrics available from cadvisor for this dashboard. It can be interesting to have containers specific memory and cpu usage, while more generic metrics about the machine could be done in a node dashboard, what do you think?

With this patch it'd look like this (I've set the memory usage as a single value instead of a gauge to avoid confusion as it's not the overall memory usage) : 

![grafana docker dashboard](https://cloud.githubusercontent.com/assets/1205386/21395642/87bda144-c79d-11e6-9e9b-405e5439d109.png)
